### PR TITLE
Switch to sqrtPrice in Graph queries and calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ query PositionsByOwner($owner: Bytes!, $first: Int!, $skip: Int!) {
       id
       feeTier
       tick
-      sqrtPriceX96
+      sqrtPrice
       token0 { id symbol decimals }
       token1 { id symbol decimals }
       liquidity

--- a/src/graph/queries.ts
+++ b/src/graph/queries.ts
@@ -10,7 +10,7 @@ query PositionsByOwner($owner: Bytes!, $first: Int!, $skip: Int!) {
       id
       feeTier
       tick
-      sqrtPriceX96
+      sqrtPrice
       token0 { id symbol decimals }
       token1 { id symbol decimals }
       liquidity
@@ -47,7 +47,7 @@ query Pool($poolId: ID!) {
     id
     feeTier
     tick
-    sqrtPriceX96
+    sqrtPrice
     token0 { id symbol decimals }
     token1 { id symbol decimals }
     liquidity
@@ -65,7 +65,7 @@ query PoolDayDatas($poolId: ID!, $first: Int!) {
     volumeUSD
     tvlUSD
     feesUSD
-    sqrtPriceX96
+    sqrtPrice
     tick
   }
 }`;
@@ -85,7 +85,7 @@ query RecentSwaps($poolId: ID!, $first: Int!) {
     amount0
     amount1
     amountUSD
-    sqrtPriceX96
+    sqrtPrice
     tick
     timestamp
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ async function startup() {
   msg += `Posições: ${enriched.length}`;
   for (const p of enriched) {
     const price = priceFromSqrtPrice(
-      p.pool.sqrtPriceX96,
+      p.pool.sqrtPrice,
       Number(p.pool.token0.decimals),
       Number(p.pool.token1.decimals)
     );

--- a/src/services/signals.ts
+++ b/src/services/signals.ts
@@ -28,8 +28,8 @@ export function evaluateSignals(
 
   const dayDatas = current.poolDayDatas;
   if (dayDatas.length >= 2) {
-    const price0 = Number(dayDatas[0].sqrtPriceX96);
-    const price1 = Number(dayDatas[1].sqrtPriceX96);
+    const price0 = Number(dayDatas[0].sqrtPrice);
+    const price1 = Number(dayDatas[1].sqrtPrice);
     const ret = ((price0 - price1) / price1) * 100;
     if (Math.abs(ret) >= cfg.PRICE_MOVE_ALERT_PCT) {
       alerts.push(`Variação 24h ${ret.toFixed(2)}%`);

--- a/src/services/uniswap.ts
+++ b/src/services/uniswap.ts
@@ -12,7 +12,7 @@ export interface PositionWithData {
     id: string;
     feeTier: string;
     tick: string;
-    sqrtPriceX96: string;
+    sqrtPrice: string;
     token0: { id: string; symbol: string; decimals: string };
     token1: { id: string; symbol: string; decimals: string };
   };
@@ -60,11 +60,11 @@ export async function enrichPosition(pos: PositionWithData): Promise<PositionMet
 }
 
 export function priceFromSqrtPrice(
-  sqrtPriceX96: string,
+  sqrtPrice: string,
   token0Decimals: number,
   token1Decimals: number
 ): number {
-  const sqrt = Number(sqrtPriceX96) / 2 ** 96;
+  const sqrt = Number(sqrtPrice) / 2 ** 96;
   const price = sqrt * sqrt * 10 ** (token0Decimals - token1Decimals);
   return price;
 }


### PR DESCRIPTION
## Summary
- query `sqrtPrice` instead of `sqrtPriceX96` for pools, pool day data, and swaps
- adjust uniswap pricing and signal logic to accept `sqrtPrice`
- update startup price messaging accordingly

## Testing
- `npm run build`
- `GRAPH_API_KEY=foo UNISWAP_V3_ARBITRUM_SUBGRAPH_ID=bar WALLET_ADDRESS=0x0000000000000000000000000000000000000000 TELEGRAM_TOKEN=foo TELEGRAM_CHAT_ID=123 npm start >/tmp/start.log && tail -n 20 /tmp/start.log`

------
https://chatgpt.com/codex/tasks/task_e_68a0e20039b483278a26f9e6ce1a67f7